### PR TITLE
fix(ProtectedRoutes): return null if no user

### DIFF
--- a/src/components/ProtectedRoutes/index.jsx
+++ b/src/components/ProtectedRoutes/index.jsx
@@ -12,6 +12,8 @@ export const ProtectedRoutes = () => {
     }
   }, [user]);
 
+  if (!user) return null;
+
   return (
     <>
       <AuthModal />


### PR DESCRIPTION
Missing line, don't return children if user not logged in.