### PR TITLE
TELDEVOPS-969: Standardise workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 name: publish.yml
-run-name: Publish
+run-name: "Publish ${{ contains(github.event.head_commit.message, 'chore(main): release') && 'to Quay' || 'to ECR' }}"
 
 # Revoke almost all permissions by default and grant only those needed to each job.
 # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions

--- a/.github/workflows/test-feature-branch.yml
+++ b/.github/workflows/test-feature-branch.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
-      - name: Yarn Prepare
+      - name: Prepare Yarn
         uses: telicent-oss/shared-workflows/.github/actions/yarn-prepare@main
         with:
           node-version: 20

--- a/.github/workflows/test-feature-branch.yml
+++ b/.github/workflows/test-feature-branch.yml
@@ -16,11 +16,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
-      - name: Prepare Yarn
+      - name: Yarn Prepare
         uses: telicent-oss/shared-workflows/.github/actions/yarn-prepare@main
         with:
           node-version: 20
           additional-args: '--network-timeout 600000'
       - name: Run tests
-        run: yarn test
+        run: yarn test --coverage --reporters=default --reporters=jest-ctrf-json-reporter
         shell: bash
+      - name: Test report summary
+        uses: ctrf-io/github-test-reporter@v1
+        if: always()
+        with:
+          report-path: './ctrf/ctrf-report.json'
+          github-report: true
+          annotate: false

--- a/.github/workflows/test-feature-branch.yml
+++ b/.github/workflows/test-feature-branch.yml
@@ -1,5 +1,5 @@
 name: test-feature-branch.yml
-run-name: Test feature branch
+run-name: Test Feature Branch
 
 on:
   push:

--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -1,5 +1,5 @@
 name: vulnerability-scanning.yml
-run-name: Vulnerability scanning
+run-name: Vulnerability Scanning
 
 permissions:
   actions: read
@@ -28,7 +28,7 @@ jobs:
         run: |
           sudo apt-get install jq
           APP_NAME=$(jq -r '.app_name // error("app_name missing from ./src/app.config.json")' ./src/app.config.json) && \
-            echo "app-name=$APP_NAME" >> $GITHUB_OUTPUT && echo "APP_NAME: $APP_NAME";
+            echo "app-name=$APP_NAME" >> $GITHUB_OUTPUT && echo "APP_NAME: $APP_NAME"
       - name: Run vulnerability scanning
         uses: telicent-oss/shared-workflows/.github/actions/trivy-repo-scan@main
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ pids
 lib-cov
 
 # Coverage directory used by tools like istanbul
+ctrf
 coverage
 *.lcov
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,6 @@ module.exports = {
   },
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.js'], // Jest setup file
   transformIgnorePatterns: ['node_modules/(?!axios)/'],
+
+  collectCoverageFrom: ["**/*.{js,jsx,vue}", "!**/node_modules/**"], // Collect coverage only from JS, JSX, and Vue files, and ignore node_modules
 };

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "globals": "^15.14.0",
     "husky": "^7.0.0",
     "jest": "^29.7.0",
+    "jest-ctrf-json-reporter": "^0.0.10",
     "jest-environment-jsdom": "^29.7.0",
     "prettier": "^3.3.2",
     "react-app-rewired": "^2.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7184,6 +7184,11 @@ jest-config@^29.7.0:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
+jest-ctrf-json-reporter@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/jest-ctrf-json-reporter/-/jest-ctrf-json-reporter-0.0.10.tgz#68e32b59741fc6a6145b08a1b82c7e96f8caf4b9"
+  integrity sha512-HELNSYkYzyYs9J54f/2+mtxPNwhDdTJbWb2VLniAFXiV5dHiFGKCbIsQZActyYzjm411VdYRq0Gp+Hx8cwv7zw==
+
 jest-diff@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"


### PR DESCRIPTION
Jira ticket: https://telicent.atlassian.net/browse/TELDEVOPS-969

---

Use OSS Actions for all front end workflows. This task has also resulted in some minor changes to workflows in OSS projects to ensure standardisation.

Additionally, the Publish workflow will now generate runs called either "Publish to ECR" or "Publish to Quay", depending on whether a dev or release image is being published.

For this repository only, the Run Feature Test workflow will now output a summary of test results in the Action summary. If this is useful we can look to extend to the other repos, however it's not simply cut and paste as a variety of test suites seem to be in use. If it's not useful, it can be removed.