### PR TITLE
chore: notify MS Teams on vulnerability scan or image push error

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -164,6 +164,7 @@ jobs:
           registry: quay
           version: ${{ needs.prepare.outputs.semver }}
           # Secrets
+          teams-webhook-url: ${{ secrets.MS_TEAMS_WEBHOOK_URL_FE }}
           quay-username: ${{ secrets.QUAY_USERNAME }}
           quay-token: ${{ secrets.QUAY_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -35,3 +35,12 @@ jobs:
           app-name: ${{ steps.app_config.outputs.app-name }}
           node-version: 20
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Notify MS Teams on failed Trivy repo scan
+        if: failure() && github.event_name == 'schedule'
+        uses: telicent-oss/shared-workflows/.github/actions/notify-teams@main
+        with:
+          app-name: ${{ steps.app_config.outputs.app-name }}
+          notification-type: trivy-repo-scan-failed
+          teams-webhook-url: ${{ secrets.MS_TEAMS_WEBHOOK_URL_FE }}
+          download-artifact: repo-scan-trivy-report
+          trivy-report-file: repo-scan-trivy-report.json


### PR DESCRIPTION
Tickets:
- https://telicent.atlassian.net/browse/TELDEVOPS-983
- https://telicent.atlassian.net/browse/TELDEVOPS-988

### Goal

- Send MS Teams notification for failed scheduled run on the Vulnerability Scanning workflow (HIGH or CRITICAL only)
- Send MS Teams notification for failed push of container image to Quay.io